### PR TITLE
show message in Logic Viewer

### DIFF
--- a/src/com/sierra/agi/debug/LogicViewer.java
+++ b/src/com/sierra/agi/debug/LogicViewer.java
@@ -87,22 +87,7 @@ public class LogicViewer extends JFrame implements ActionListener
                     {
                         writer.println(component.getLineText(i));
                     }
-                    
-                    m = logic.getMessages();
 
-                    if (m != null)
-                    {
-                        writer.println();
-                        writer.println();
-                        writer.println("Messages:");
-
-                        for (i = 0; i < m.length; i++)
-                        {
-                            writer.print("Message #" + i + ": ");
-                            writer.println(m[i]);
-                        }
-                    }
-                
                     writer.close();
                 }
                 catch (IOException ioex)

--- a/src/com/sierra/agi/debug/logic/LogicEvaluator.java
+++ b/src/com/sierra/agi/debug/logic/LogicEvaluator.java
@@ -304,6 +304,19 @@ public class LogicEvaluator
         decompile(logicInterpreter, instructions, result);
 
         result.add(new LogicLine(0, "}"));
+
+        String[] messages = logicInterpreter.getMessages();
+
+        if (messages != null)
+        {
+            result.add(new LogicLine(0, ""));
+            result.add(new LogicLine(0, "Messages"));
+            for (int i = 0; i < messages.length; i++)
+            {
+                result.add(new LogicLine(0, "Message #" + i + ": " + messages[i]));
+            }
+        }
+
         return result;
     }
     


### PR DESCRIPTION
Display messages in Logic Viewer

Currently, the only way to see the messages in the Logic file is to do "Save as Text File"

![messages](https://user-images.githubusercontent.com/285941/197574579-30c02f51-bf57-47f8-ace4-5145412136c8.PNG)
